### PR TITLE
fixing cmp family return value

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 12
+        sudo ./llvm.sh 12 all
 
     - name: Configure
       run: CC=clang-12 CXX=clang++-12 cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         sudo ./llvm.sh 12
 
     - name: Configure
-      run: CC=clang-12 CXX=clang-12 cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release
+      run: CC=clang-12 CXX=clang++-12 cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release
 
     - name: Build
       run: cmake --build ${{ github.workspace }}/build --config Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       run: CC=clang-12 CXX=clang++-12 cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release
 
     - name: Build
-      run: cmake --build ${{ github.workspace }}/build --config Release
+      run: CC=clang-12 CXX=clang++-12 cmake --build ${{ github.workspace }}/build --config Release
 
     - name: Test
       run: |

--- a/runtime/dfsan/dfsan_custom.cpp
+++ b/runtime/dfsan/dfsan_custom.cpp
@@ -208,7 +208,7 @@ SANITIZER_INTERFACE_ATTRIBUTE int __dfsw_memcmp(const void *s1, const void *s2,
   dfsan_label ls2 = dfsan_read_label(s2, n);
   // ugly hack ...
   *ret_label = dfsan_union(ls1, ls2, fmemcmp, n, (u64)s1, (u64)s2);
-  return !!ret;
+  return ret;
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE int __dfsw_bcmp(const void *s1, const void *s2,
@@ -222,7 +222,7 @@ SANITIZER_INTERFACE_ATTRIBUTE int __dfsw_bcmp(const void *s1, const void *s2,
   dfsan_label ls2 = dfsan_read_label(s2, n);
   // ugly hack ...
   *ret_label = dfsan_union(ls1, ls2, fmemcmp, n, (u64)s1, (u64)s2);
-  return !!ret;
+  return ret;
 }
 
 DECLARE_WEAK_INTERCEPTOR_HOOK(dfsan_weak_hook_strcmp, uptr caller_pc,
@@ -245,7 +245,7 @@ SANITIZER_INTERFACE_ATTRIBUTE int __dfsw_strcmp(const char *s1, const char *s2,
   dfsan_label ls2 = dfsan_read_label(s2, size);
   // ugly hack ...
   *ret_label = dfsan_union(ls1, ls2, fmemcmp, size, (u64)s1, (u64)s2);
-  return !!ret;
+  return ret;
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE int
@@ -262,7 +262,7 @@ __dfsw_strcasecmp(const char *s1, const char *s2, dfsan_label s1_label,
   dfsan_label ls2 = dfsan_read_label(s2, size);
   // ugly hack ...
   *ret_label = dfsan_union(ls1, ls2, fmemcmp, size, (u64)s1, (u64)s2);
-  return !!ret;
+  return ret;
 }
 
 DECLARE_WEAK_INTERCEPTOR_HOOK(dfsan_weak_hook_strncmp, uptr caller_pc,
@@ -293,7 +293,7 @@ SANITIZER_INTERFACE_ATTRIBUTE int __dfsw_strncmp(const char *s1, const char *s2,
   dfsan_label ls2 = dfsan_read_label(s2, n);
   // ugly hack ...
   *ret_label = dfsan_union(ls1, ls2, fmemcmp, n, (u64)s1, (u64)s2);
-  return !!ret;
+  return ret;
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE int
@@ -316,7 +316,7 @@ __dfsw_strncasecmp(const char *s1, const char *s2, size_t n,
   dfsan_label ls2 = dfsan_read_label(s2, n);
   // ugly hack ...
   *ret_label = dfsan_union(ls1, ls2, fmemcmp, n, (u64)s1, (u64)s2);
-  return !!ret;
+  return ret;
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE size_t


### PR DESCRIPTION
Previously I used a hack to make sure these functions only return 0 or 1, but this seems unnecessary and will cause problems (e.g., std::map in libcxx).