### PR TITLE
Fix bug in isLoopLatch

### DIFF
--- a/instrumentation/TaintPass.cpp
+++ b/instrumentation/TaintPass.cpp
@@ -2272,12 +2272,16 @@ void TaintVisitor::visitPHINode(PHINode &PN) {
 
 static inline bool isLoopLatch(const BasicBlock *BB, const BasicBlock *Header) {
   const BasicBlock *Succ = nullptr;
-  if (BB == Header)
-    return true;
-  else if ((Succ = BB->getSingleSuccessor()) != nullptr)
-    return isLoopLatch(Succ, Header);
-  else
-    return false;
+  std::vector<const BasicBlock *> Visited;
+  while (BB != Header) {
+    Visited.push_back(BB);
+    if ((Succ = BB->getSingleSuccessor()) == nullptr)
+      return false;
+    BB = Succ;
+    if (Visited.end() != std::find(Visited.begin(), Visited.end(), BB))
+      return false; // found a cycle
+  }
+  return true;
 }
 
 void TaintFunction::visitCondition(Value *Condition, Instruction *I) {

--- a/instrumentation/TaintPass.cpp
+++ b/instrumentation/TaintPass.cpp
@@ -2272,7 +2272,7 @@ void TaintVisitor::visitPHINode(PHINode &PN) {
 
 static inline bool isLoopLatch(const BasicBlock *BB, const BasicBlock *Header) {
   const BasicBlock *Succ = nullptr;
-  std::vector<const BasicBlock *> Visited;
+  SmallVector<const BasicBlock*> Visited;
   while (BB != Header) {
     Visited.push_back(BB);
     if ((Succ = BB->getSingleSuccessor()) == nullptr)


### PR DESCRIPTION
Fix segfault when isLoopLatch encounters a cycle loop


Example:
```llvm
BB-13: ; preds = %BB-14, %BB-12
  br label %BB-14, !dbg !21273

BB-14: ; preds = %BB-13
  br i1 true, label %BB-13, label %BB-15, !dbg !21273, !llvm.loop !21275
```

In this case, the old implementation of `isLoopLatch` will be recursive forever until a segfault is triggered.
