### PR TITLE
Install libunwind-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:focal
 WORKDIR /workdir
 COPY . /workdir/symsan
 RUN apt-get update
-RUN apt-get install -y cmake llvm-12 clang-12 libc++-12-dev libc++abi-12-dev python zlib1g-dev
+RUN apt-get install -y cmake llvm-12 clang-12 libc++-12-dev libc++abi-12-dev python zlib1g-dev libunwind-dev
 RUN cd symsan/ && mkdir -p build && \
     cd build && CC=clang-12 CXX=clang++-12 cmake -DCMAKE_INSTALL_PREFIX=. ../  && \
     make -j && make install


### PR DESCRIPTION
Compiling C programs requires `libunwind` library. This PR installs` libunwind-dev` in the docker containers. Partial solve #22 